### PR TITLE
fix 422by sending JSON content-type header

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -23,6 +23,7 @@ placeholder="Win a FREE prize now"></textarea><br><br>
         // 브라우저가 서버에 HTTP 요청을 보내는 함수
         fetch("/classify", {
             method: "POST",
+            headers: {"Content-Type": "application/json"},
             body: JSON.stringify({text})
         })
         .then(res => res.json())


### PR DESCRIPTION
What: Add Content-Type: application/json header to classify request

Why: FastAPI Pydantic body binding requires JSON content-type

Test: pytest locally + CI should pass